### PR TITLE
Support for resuming training from the specified or the latest checkpoint

### DIFF
--- a/uniform_finetune.py
+++ b/uniform_finetune.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
                         help="the module to be injected, e.g. q_proj/v_proj/k_proj/o_proj for llama, query_key_value for bloom&GLM", 
                         default=["q_proj", "v_proj"])
 
-    args = parser.parse_args()
+    args, _ = parser.parse_known_args()
     print(args)
     
     train(args)

--- a/uniform_finetune.py
+++ b/uniform_finetune.py
@@ -318,7 +318,7 @@ def train(args):
     if torch.__version__ >= "2" and sys.platform != "win32":
         model = torch.compile(model)
 
-    trainer.train()
+    trainer.train(resume_from_checkpoint=args.resume_from_checkpoint)
 
     model.save_pretrained(output_dir)
 
@@ -345,6 +345,7 @@ if __name__ == "__main__":
     parser.add_argument('--lora_target_modules', nargs='+', 
                         help="the module to be injected, e.g. q_proj/v_proj/k_proj/o_proj for llama, query_key_value for bloom&GLM", 
                         default=["q_proj", "v_proj"])
+    parser.add_argument('--resume_from_checkpoint', nargs='?', default=None, const=True, help='resume from the specified or the latest checkpoint, e.g. `--resume_from_checkpoint [path]` or `--resume_from_checkpoint`')
 
     args, _ = parser.parse_known_args()
     print(args)


### PR DESCRIPTION
This PR adds support for resuming training from the specified or the latest checkpoint, with one new command line argument `--resume_from_checkpoint` using [`Trainer.train(resume_from_checkpoint=...)`](https://huggingface.co/docs/transformers/main_classes/trainer#transformers.Trainer.train.resume_from_checkpoint).

(also allows extra arguments like `--report_to` because that was just changing one line of code and doesn't need a separate PR, this is also tested while testing `--resume_from_checkpoint`)

The usages look like the following, I've [tested on Colab](https://github.com/utensil/llm-playground/blob/main/notebooks/Alpaca-CoT/04_test_resume_pr.ipynb) and an A6000 for 1 epoch :

## Usage 1: instruction finetuning from scratch

Don't pass `--resume_from_checkpoint` as usual:

```
!cd /workspace/code && python uniform_finetune.py --model_type llama --model_name_or_path decapoda-research/llama-7b-hf --data alpaca --lora_target_modules q_proj v_proj --per_gpu_train_batch_size 4 --learning_rate 3e-4 --epochs 1 --report_to wandb
```

Output (noisy logs omitted ):

```
Namespace(size=None, data='alpaca', local_rank=-1, model_type='llama', model_name_or_path='decapoda-research/llama-7b-hf', per_gpu_train_batch_size=4, gradient_accumulation_steps=32, epochs=1, learning_rate=0.0003, cutoff_len=512, lora_r=8, lora_alpha=16, lora_dropout=0.05, val_set_size=2000, lora_target_modules=['q_proj', 'v_proj'], resume_from_checkpoint=None)
...
0% 1/390 [01:27<9:27:53, 87.59s/it]
```

Note the value of `resume_from_checkpoint` which is the rightmost one and `1/390` indicates it's a fresh start.

## Usage 2: instruction finetuning from the latest checkpoint

Just pass `--resume_from_checkpoint` with no arguments:

```
!cd /workspace/code && python uniform_finetune.py --model_type llama --model_name_or_path decapoda-research/llama-7b-hf --data alpaca --lora_target_modules q_proj v_proj --per_gpu_train_batch_size 4 --learning_rate 3e-4 --epochs 3 --report_to wandb --resume_from_checkpoint
```

Output:

```
Namespace(size=None, data='alpaca', local_rank=-1, model_type='llama', model_name_or_path='decapoda-research/llama-7b-hf', per_gpu_train_batch_size=4, gradient_accumulation_steps=32, epochs=3, learning_rate=0.0003, cutoff_len=512, lora_r=8, lora_alpha=16, lora_dropout=0.05, val_set_size=2000, lora_target_modules=['q_proj', 'v_proj'], resume_from_checkpoint=True)
...
 67% 781/1170 [01:21<00:40,  9.59it/s
```

Note that my latest checkpoint was 780 in this case.

## Usage 3: instruction finetuning from the specified checkpoint

Just pass `--resume_from_checkpoint` with the path to the specified checkpoint:

```
!cd /workspace/code && python uniform_finetune.py --model_type llama --model_name_or_path decapoda-research/llama-7b-hf --data alpaca --lora_target_modules q_proj v_proj --per_gpu_train_batch_size 4 --learning_rate 3e-4 --epochs 3 --report_to wandb --resume_from_checkpoint  /workspace/code/saved_models/llama-7b-hf_alpaca/checkpoint-351
```

Output:

```
Namespace(size=None, data='alpaca', local_rank=-1, model_type='llama', model_name_or_path='decapoda-research/llama-7b-hf', per_gpu_train_batch_size=4, gradient_accumulation_steps=32, epochs=2, learning_rate=0.0003, cutoff_len=512, lora_r=8, lora_alpha=16, lora_dropout=0.05, val_set_size=2000, lora_target_modules=['q_proj', 'v_proj'], resume_from_checkpoint='/workspace/code/saved_models/llama-7b-hf_alpaca/checkpoint-351')
...
 45% 352/780 [01:22<01:40,  4.28it/s]
```






