### PR TITLE
fix web.py

### DIFF
--- a/utils/tools.py
+++ b/utils/tools.py
@@ -188,17 +188,15 @@ def get_fine_tuned_model(args):
         model_path = args.model_path
         model_class = _get_model_class(args.model_type)
     else:
-        def _get_model_class(llm_type, model_path):
+        def _get_model_class(llm_type):
             if llm_type not in AVAILABLE_MODEL:
                 llm_type = "Auto"
-                return MODEL_CLASSES[llm_type], model_path
+                return MODEL_CLASSES[llm_type]
             else:
-                load_path = llm_type + "_" + model_path
-                if llm_type in ['moss']:
-                    load_path = llm_type
-                return MODEL_CLASSES[llm_type], COMMON_PATH + MODEL_PATHS[load_path]
+                return MODEL_CLASSES[llm_type]
 
-        model_class, model_path = _get_model_class(args.model_type, args.size)
+        model_path = args.model_path
+        model_class = _get_model_class(args.model_type)
 
     if args.model_type == "chatglm":
         model = model_class.model.from_pretrained(model_path,

--- a/web.py
+++ b/web.py
@@ -16,8 +16,8 @@ os.environ["CUDA_VISIBLE_DEVICES"] = '0'
 parser = argparse.ArgumentParser(description='Process some llm info.')
 parser.add_argument('--model_type', type=str, default="chatglm", choices=AVAILABLE_MODEL,
                     help='the base structure (not the model) used for model or fine-tuned model')
-parser.add_argument('--model_path', type=str, default="7b",
-                    help='the type for base model or the absolute path for fine-tuned model')
+parser.add_argument('--model_path', type=str, default="decapoda-research/llama-7b-hf",
+                    help='the absolute or relative or huggingface path for fine-tuned model')
 parser.add_argument('--lora_dir', type=str, default="none",
                     help='the path for fine-tuned lora params, none when not in use')
 parser.add_argument('--lora_r', default=8, type=int)
@@ -86,7 +86,10 @@ async def create_item(request: Request):
     prompt = json_post_list.get("prompt")
     messages = []
     messages.append({"role": "user", "content": prompt})
-    response = model.chat(tokenizer, messages)
+    if(args.model_type=="baichuan"):
+        response = model.chat(tokenizer, messages)
+    else:
+        response = server(prompt)
 
     now = datetime.datetime.now()
     time = now.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
1. 在tool.py文件中，取消了根据文件大小读取模型的相关代码，现在支持直接通过相对或绝对路径进行读取模型
2. web.py运行命令为：python web.py --model_type llama --model_path /mnt/weijie/openbuddy-llama2-13b-v11.1-bf16 --compute_dtype bf16
3. API调用代码可以为：
data_dic = {"prompt": in_str}
response = requests.post(url="http://localhost:8410", json=data_dic)
response = json.loads(response.text)